### PR TITLE
Add note on SQL specified in batch processing

### DIFF
--- a/src/basics/entity-api.md
+++ b/src/basics/entity-api.md
@@ -933,18 +933,19 @@ public class Employee {
 
 これらのアノテーションが付与されたフィールドは自動採番フィールドになります。  
 `@Id`と`@GeneratedValue`は必ずセットでフィールドに付与する必要があります。  
-`@GeneratedValue`のstrategy属性が`GenerationType.SEQUENCE`の場合に`@SequenceGenerator`を付与してシーケンスの生成方法を指定する必要があります。
+`@GeneratedValue`のstrategy属性が`GenerationType.SEQUENCE`の場合に`@SequenceGenerator`を付与してシーケンスの生成方法を指定する必要があります。  
+１つのエンティティに属する複数のフィールドを自動採番フィールドとして指定することも可能です。
 
 | アノテーション     | 説明                                         |
 | :----------------- | :------------------------------------------- |
-| @Id                | エンティティの主キーを識別するアノテーション |
-| @GeneratedValue    | 主キーの値の生成戦略を指定するアノテーション |
-| @SequenceGenerator | SEQUENCEによるID生成を設定するアノテーション |
+| @Id                | エンティティの自動採番フィールドを識別するアノテーション |
+| @GeneratedValue    | 自動採番フィールドの値の生成戦略を指定するアノテーション |
+| @SequenceGenerator | ID生成に使用するSEQUENCEの情報を設定するアノテーション |
 
 | アノテーション     | 属性名   | 型             | 必須  | 説明                                                                                     | 初期値                  |
 | :----------------- | :------- | :------------- | :---: | :--------------------------------------------------------------------------------------- | :---------------------- |
 | @Id                | なし     | -              |   -   | -                                                                                        | -                       |
-| @GeneratedValue    | strategy | GenerationType |   -   | 主キー生成戦略の型。`GenerationType.IDENTITY`, `GenerationType.SEQUENCE`のいずれかを指定 | GenerationType.IDENTITY |
+| @GeneratedValue    | strategy | GenerationType |   -   | ID生成戦略の型。`GenerationType.IDENTITY`, `GenerationType.SEQUENCE`のいずれかを指定 | GenerationType.IDENTITY |
 | @SequenceGenerator | sequence | String         |  〇   | シーケンス名                                                                             | なし                    |
 | @SequenceGenerator | catalog  | String         |   -   | シーケンスが所属するカタログ名                                                           | ""                      |
 | @SequenceGenerator | schema   | String         |   -   | シーケンスが所属するスキーマ名                                                           | ""                      |
@@ -958,9 +959,13 @@ import jp.co.future.uroborosql.mapping.annotations.SequenceGenerator;
 @Table
 public class Employee {
   @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long empId;
+
+  @Id
   @GeneratedValue(strategy = GenerationType.SEQUENCE)
-  @SequenceGenerator(sequence = 'employee_emp_id_seq')
-  private long empNo;
+  @SequenceGenerator(sequence = 'employee_emp_detail_id_seq')
+  private long empDetailId;
 
   private String firstName;
 

--- a/src/basics/sql-file-api.md
+++ b/src/basics/sql-file-api.md
@@ -716,7 +716,7 @@ try (SqlAgent agent = config.agent()) {
 
 上記２つのメソッドはバッチ更新を行うための`SqlBatch`インタフェースのインスタンスを返却します。
 
-::: warning batch/batchWith に指定するSQLの注意点
+::: danger batch/batchWith に指定するSQLの注意点
 batch/batchWithの内部では `PreparedStatement` を作成し、渡されたパラメータをバインドしながら `PreparedStatement#executeBatch()` メソッドを呼び出すことでバッチ処理を行っています。  
 その際 `PreparedStatement` は、引数で渡されたSQLを**1件目のデータ**で評価したSQLを元に生成し、この `PreparedStatement` をバッチ処理が終了するまで利用します。  
 そのため、SQLの中に 条件分岐（`/*IF*/` など）や埋め込み文字（`/*# */` など）を記載していると、1件目のデータで条件分岐や埋め込みをしたSQLを元に `PreparedStatement` が生成されて2件目以降のデータでも利用されることになり、意図しない結果になります。  

--- a/src/basics/sql-file-api.md
+++ b/src/basics/sql-file-api.md
@@ -716,6 +716,55 @@ try (SqlAgent agent = config.agent()) {
 
 上記２つのメソッドはバッチ更新を行うための`SqlBatch`インタフェースのインスタンスを返却します。
 
+::: warning batch/batchWith に指定するSQLの注意点
+batch/batchWithの内部では `PreparedStatement` を作成し、渡されたパラメータをバインドしながら `PreparedStatement#executeBatch()` メソッドを呼び出すことでバッチ処理を行っています。  
+その際 `PreparedStatement` は、引数で渡されたSQLを**1件目のデータ**で評価したSQLを元に生成し、この `PreparedStatement` をバッチ処理が終了するまで利用します。  
+そのため、SQLの中に 条件分岐（`/*IF*/` など）や埋め込み文字（`/*# */` など）を記載していると、1件目のデータで条件分岐や埋め込みをしたSQLを元に `PreparedStatement` が生成されて2件目以降のデータでも利用されることになり、意図しない結果になります。  
+このことから、バッチ処理で使用するSQLには条件分岐やデータ毎に変化する埋め込み文字を **使用しないようにする必要があります**。  
+
+例）  
+下記のようなデータを
+
+|id|name|age|
+|:--|:--|:--|
+|null|taro|13|
+|2|hanako|15|
+|3|jiro|10|
+
+以下のSQLでバッチインサートすると
+
+```sql
+insert into person (
+/*IF id != null */
+  id,
+/*END*/
+  name,
+  age
+) values (
+/*IF id != null */
+/*id*/,
+/*END*/
+/*name*/,
+/*age*/
+)
+```
+
+１件目のデータ（id=null, name=taro, age=13）を使ってSQLが評価され以下のようになる
+
+```sql
+insert into person (
+  name,
+  age
+) values (
+/*name*/,
+/*age*/
+)
+```
+
+このSQLでバッチインサートが行われると、2件目、3件目のデータで指定していた `id` の値がDBに格納されなくなります。
+
+:::
+
 `SqlBatch`インタフェースでは、`SqlFluent`インタフェースによるバインドパラメータの設定とは別に`java.util.stream.Stream`を用いたバッチパラメータの設定を行うAPIが提供されています。
 
 | メソッド                                              | 説明                                                                                                                                     |


### PR DESCRIPTION
Added an explanation to the effect that conditional branching in SQL specified for batch processing is prohibited because it causes unexpected behavior.